### PR TITLE
fix $screenSizeClassName not being a string.

### DIFF
--- a/source/php/Component/Drawer/drawer.blade.php
+++ b/source/php/Component/Drawer/drawer.blade.php
@@ -37,4 +37,4 @@
     </div>
 </nav>
 
-<div class="drawer-overlay js-close-drawer {{$screenSizeClassNames}}" data-simulate-click="{{$simulateClickSelector}}" {!! $moveTo !!}></div>
+<div class="drawer-overlay js-close-drawer {{ implode(' ', $screenSizeClassNames) }}" data-simulate-click="{{$simulateClickSelector}}" {!! $moveTo !!}></div>


### PR DESCRIPTION
Uses implode to convert the array into a string.

#312 