### PR TITLE
Use mb_substr if possible

### DIFF
--- a/source/php/Helper/Truncate.php
+++ b/source/php/Helper/Truncate.php
@@ -9,6 +9,10 @@ class Truncate {
             return $content;
         }
 
+        if (function_exists('mb_substr')) {
+            return mb_substr($content, 0, $length) . $suffix;
+        }
+
         return substr($content, 0, $length) . $suffix;
     }
 }


### PR DESCRIPTION
Using substr might cause an issue with multibyte characters, where it breaks in the middle of a special character. This causes the output, for instance a breadcrumb label, to not render properly.