### PR TITLE
feat: megamenu child style

### DIFF
--- a/source/php/Component/MegaMenu/megaMenu.blade.php
+++ b/source/php/Component/MegaMenu/megaMenu.blade.php
@@ -55,23 +55,39 @@
                     <ul class="{{$baseClass}}__sublist unlist u-margin__top--2">
                         @foreach ($item['children'] as $child)
                             <li id="{{$id}}-item-{{$child['id']}}" class="{{$baseClass}}__item {{$baseClass}}__item--child {{ $child['classNames'] }}">
-                                @link([
-                                    'href' => $child['href'],
-                                    'classList' => [
-                                        $baseClass . '__link', 
-                                        $baseClass . '__link--child'
-                                    ]
-                                ])
-                                @if(isset($child['icon']) && !array_diff(['icon', 'size', 'classList'], array_keys($child['icon'])))
-                                    @icon([
-                                        'icon' => $child['icon']['icon'],
-                                        'size' => $child['icon']['size'],
-                                        'classList' => $child['icon']['classList'],
+                                @if(!empty($childStyle))
+                                    @button([
+                                        'text' => $item['label'],
+                                        'style' => $childStyle,
+                                        'color' => $childStyleColor ?? 'primary',
+                                        'icon' => $item['icon']['icon'] !== "" ? $item['icon']['icon'] : 'chevron_right',
+                                        'href' => $item['href'],
+                                        'size' => 'sm',
+                                        'classList' => [
+                                            $baseClass . '__link',
+                                            $baseClass . '__link--button',
+                                        ]
                                     ])
-                                    @endicon
+                                    @endbutton
+                                @else
+                                    @link([
+                                        'href' => $child['href'],
+                                        'classList' => [
+                                            $baseClass . '__link', 
+                                            $baseClass . '__link--child'
+                                        ]
+                                    ])
+                                    @if(isset($child['icon']) && !array_diff(['icon', 'size', 'classList'], array_keys($child['icon'])))
+                                        @icon([
+                                            'icon' => $child['icon']['icon'],
+                                            'size' => $child['icon']['size'],
+                                            'classList' => $child['icon']['classList'],
+                                        ])
+                                        @endicon
+                                    @endif
+                                        {{ $child['label'] }}
+                                    @endlink
                                 @endif
-                                    {{ $child['label'] }}
-                                @endlink
                             </li>
                         @endforeach
                     </ul>

--- a/source/php/Component/MegaMenu/megaMenu.blade.php
+++ b/source/php/Component/MegaMenu/megaMenu.blade.php
@@ -50,6 +50,7 @@
                         {{ $item['description'] }}
                     @endtypography
                 @endif
+
                 {{-- Children --}}
                 @if (!empty($item['children']))
                     <ul class="{{$baseClass}}__sublist {{$baseClass}}__sublist--{{ ($childStyle ? 'flex' : 'list') }} unlist u-margin__top--2">

--- a/source/php/Component/MegaMenu/megaMenu.blade.php
+++ b/source/php/Component/MegaMenu/megaMenu.blade.php
@@ -52,16 +52,17 @@
                 @endif
                 {{-- Children --}}
                 @if (!empty($item['children']))
-                    <ul class="{{$baseClass}}__sublist unlist u-margin__top--2">
+                    <ul class="{{$baseClass}}__sublist {{$baseClass}}__sublist--{{ ($childStyle ? 'flex' : 'list') }} unlist u-margin__top--2">
                         @foreach ($item['children'] as $child)
                             <li id="{{$id}}-item-{{$child['id']}}" class="{{$baseClass}}__item {{$baseClass}}__item--child {{ $child['classNames'] }}">
                                 @if(!empty($childStyle))
                                     @button([
-                                        'text' => $item['label'],
+                                        'text' => $child['label'],
                                         'style' => $childStyle,
                                         'color' => $childStyleColor ?? 'primary',
-                                        'icon' => $item['icon']['icon'] !== "" ? $item['icon']['icon'] : 'chevron_right',
-                                        'href' => $item['href'],
+                                        'shape' => $childStyleShape ?? 'pill',
+                                        'icon' => $child['icon']['icon'] !== "" ? $child['icon']['icon'] : 'chevron_right',
+                                        'href' => $child['href'],
                                         'size' => 'sm',
                                         'classList' => [
                                             $baseClass . '__link',

--- a/source/php/Component/MegaMenu/megaMenu.blade.php
+++ b/source/php/Component/MegaMenu/megaMenu.blade.php
@@ -68,7 +68,8 @@
                                         'classList' => [
                                             $baseClass . '__link',
                                             $baseClass . '__link--button',
-                                        ]
+                                        ],
+                                        'context' => ['component.megamenu.button.child']
                                     ])
                                     @endbutton
                                 @else

--- a/source/php/Component/MegaMenu/megaMenu.json
+++ b/source/php/Component/MegaMenu/megaMenu.json
@@ -6,6 +6,7 @@
         "parentStyleColor": "primary",
         "childStyle": false,
         "childStyleColor": "primary",
+        "childStyleShape": "pill",
         "mobile": false
     },
     "types": {
@@ -14,11 +15,16 @@
         "parentStyleColor": "string",
         "childStyle": "boolean",
         "childStyleColor": "string",
+        "childStyleShape": "string",
         "mobile": "boolean"
     },
     "description": {
         "menuItems": "List of arrays containing at least 'label' and 'href' option 'icon' name as string.",
         "parentStyle": "Select the style of menu parents.",
+        "parentStyleColor": "Select the color of the parent style.",
+        "childStyle": "Select the style of menu children.",
+        "childStyleColor": "Select the color of the child style.",
+        "childStyleShape": "Select the shape of the child style.",
         "mobile": "If true, the mega menu will be visible on mobile as well."
     },
     "view": "megaMenu.blade.php",

--- a/source/php/Component/MegaMenu/megaMenu.json
+++ b/source/php/Component/MegaMenu/megaMenu.json
@@ -11,9 +11,9 @@
     },
     "types": {
         "menuItems": "array",
-        "parentStyle": "boolean",
+        "parentStyle": "string|boolean",
         "parentStyleColor": "string",
-        "childStyle": "boolean",
+        "childStyle": "string|boolean",
         "childStyleColor": "string",
         "childStyleShape": "string",
         "mobile": "boolean"

--- a/source/php/Component/MegaMenu/megaMenu.json
+++ b/source/php/Component/MegaMenu/megaMenu.json
@@ -4,7 +4,17 @@
         "menuItems": [],
         "parentStyle": false,
         "parentStyleColor": "primary",
+        "childStyle": false,
+        "childStyleColor": "primary",
         "mobile": false
+    },
+    "types": {
+        "menuItems": "array",
+        "parentStyle": "boolean",
+        "parentStyleColor": "string",
+        "childStyle": "boolean",
+        "childStyleColor": "string",
+        "mobile": "boolean"
     },
     "description": {
         "menuItems": "List of arrays containing at least 'label' and 'href' option 'icon' name as string.",


### PR DESCRIPTION
This pull request introduces enhancements to the MegaMenu component by adding customizable styles for child menu items. The main changes include updating the Blade template to support conditional rendering of child items as buttons and extending the JSON configuration to include new properties for child item styles.

Changes to Blade template:

* Updated `source/php/Component/MegaMenu/megaMenu.blade.php` to conditionally render child items as buttons if `childStyle` is set. This includes adding button attributes such as `text`, `style`, `color`, `shape`, `icon`, `href`, `size`, and `classList`.
* Added an `@endif` statement to close the conditional block for child item buttons.

Changes to JSON configuration:

* Updated `source/php/Component/MegaMenu/megaMenu.json` to include new properties: `childStyle`, `childStyleColor`, and `childStyleShape`. These properties allow customization of the style, color, and shape of child menu items.