### PR TITLE
fix(Date): allow format override

### DIFF
--- a/source/php/Component/Date/Config/DateConfig.php
+++ b/source/php/Component/Date/Config/DateConfig.php
@@ -4,7 +4,8 @@ namespace ComponentLibrary\Component\Date\Config;
 
 class DateConfig
 {
-    private string $dateFormat = 'D d M Y';
+    private string $fallbackDateFormat = 'D d M Y';
+    private ?string $dateFormat = null;
 
     /**
      * Get the date format
@@ -13,7 +14,7 @@ class DateConfig
      */
     public function getDateFormat(): string
     {
-      return $this->dateFormat;
+      return $this->dateFormat ?? $this->fallbackDateFormat;
     }
 
     /**

--- a/source/php/Component/Date/date.json
+++ b/source/php/Component/Date/date.json
@@ -4,7 +4,7 @@
         "timestamp": "",
         "time_since": false,
         "time_since_cap": "6 months",
-        "format": "D d M Y",
+        "format": null,
         "region": "en_US",
         "timezone": "UTC",
         "action": "formatDate",


### PR DESCRIPTION
This pull request updates how date formatting is handled in the `DateConfig` component, improving flexibility and fallback behavior. The main change is that the date format can now be explicitly set to `null`, and a fallback format will be used if no format is provided.

**Date format handling improvements:**

* Changed the `dateFormat` property in `DateConfig` to be nullable and introduced a separate `fallbackDateFormat` property for default formatting.
* Updated the `getDateFormat()` method in `DateConfig` to return the fallback format if the main format is not set.

**Configuration update:**

* Modified the default date format in `date.json` to `null`, allowing the fallback logic to take effect.